### PR TITLE
chore(mdn_popularities): remove mdn_yari Glean data

### DIFF
--- a/sql/moz-fx-data-shared-prod/mdn_yari_derived/mdn_popularities_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/mdn_yari_derived/mdn_popularities_v1/query.py
@@ -10,24 +10,14 @@ from uuid import uuid4
 from google.cloud import bigquery, storage
 
 QUERY_TEMPLATE = """\
-WITH events_stream AS
-  (SELECT JSON_VALUE(event_extra.url) AS url
-   FROM `moz-fx-data-shared-prod.mdn_fred.events_stream`
-   WHERE DATE(submission_timestamp) BETWEEN DATE_TRUNC(@submission_date, MONTH) AND LAST_DAY(@submission_date)
-     AND client_info.app_channel = 'prod'
-     AND event_name = 'page_load'
-     AND JSON_VALUE(event_extra.url) LIKE "https://developer.mozilla.org/%/docs/%"
-     AND JSON_VALUE(event_extra.title) != 'Page not found | MDN'
-   UNION ALL SELECT JSON_VALUE(event_extra.url) AS url
-   FROM `moz-fx-data-shared-prod.mdn_yari.events_stream`
-   WHERE DATE(submission_timestamp) BETWEEN DATE_TRUNC(@submission_date, MONTH) AND LAST_DAY(@submission_date)
-     AND client_info.app_channel = 'prod'
-     AND event_name = 'page_load'
-     AND JSON_VALUE(event_extra.url) LIKE "https://developer.mozilla.org/%/docs/%"
-     AND JSON_VALUE(event_extra.title) NOT LIKE '%Page not found | MDN' )
-SELECT REGEXP_EXTRACT(url, r'^https://developer.mozilla.org(/.+?/docs/[^?#]+)') AS Page,
+SELECT REGEXP_EXTRACT(JSON_VALUE(event_extra.url), r'^https://developer.mozilla.org(/.+?/docs/[^?#]+)') AS Page,
        COUNT(*) AS Pageviews
-FROM events_stream
+FROM `moz-fx-data-shared-prod.mdn_fred.events_stream`
+WHERE DATE(submission_timestamp) BETWEEN DATE_TRUNC(@submission_date, MONTH) AND LAST_DAY(@submission_date)
+  AND client_info.app_channel = 'prod'
+  AND event_name = 'page_load'
+  AND JSON_VALUE(event_extra.url) LIKE "https://developer.mozilla.org/%/docs/%"
+  AND JSON_VALUE(event_extra.title) != 'Page not found | MDN'
 GROUP BY Page
 ORDER BY Pageviews DESC
 """


### PR DESCRIPTION
## Description

Now that the MDN popularities for August were calculated, we no longer need to incorporate yari data from the old and no longer deployed front end.

## Related Tickets & Documents
* Follow-up of https://github.com/mozilla/bigquery-etl/pull/7980.
* Fixes https://github.com/mdn/fred/issues/526.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
